### PR TITLE
Fix libsrtp 

### DIFF
--- a/voice-client-core/jni/android_makefiles/libsrtp.mk
+++ b/voice-client-core/jni/android_makefiles/libsrtp.mk
@@ -30,7 +30,6 @@ LOCAL_SRC_FILES := \
 LOCAL_CFLAGS := \
 	-DHAVE_STDLIB_H \
 	-DHAVE_STRING_H \
-	-DCPU_RISC \
 	-DSIZEOF_UNSIGNED_LONG=4 \
 	-DSIZEOF_UNSIGNED_LONG_LONG=8 \
 	-DHAVE_STDINT_H \
@@ -41,6 +40,14 @@ LOCAL_CFLAGS := \
 	-DHAVE_UINT16_T \
 	-DHAVE_UINT8_T \
 	-DHAVE_UINT_T
+
+
+# CPU_RISC doesn't work properly on android/arm
+# self test for aes failed. CPU_RISC is used for optimization only,
+# and CPU_CISC should just work just fine, it has been tested on android/arm with srtp
+# test applications and libjingle.
+# More info here http://src.chromium.org/svn/trunk/deps/third_party/libsrtp/libsrtp.gyp
+LOCAL_CFLAGS += -DCPU_CISC
 
 LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/source/config \

--- a/voice-client-core/jni/tuenti/clientsignalingthread.cc
+++ b/voice-client-core/jni/tuenti/clientsignalingthread.cc
@@ -693,7 +693,7 @@ void ClientSignalingThread::InitMedia() {
       &ClientSignalingThread::OnCallCreate);
   sp_media_client_->SignalCallDestroy.connect(this,
       &ClientSignalingThread::OnCallDestroy);
-  sp_media_client_->set_secure(cricket::SEC_DISABLED);
+  sp_media_client_->set_secure(cricket::SEC_ENABLED);
 }
 
 void ClientSignalingThread::InitPresence() {


### PR DESCRIPTION
libsrtp compiled with -DCPU_RISC doesn't work properly on android/arm.
Visiable effect: AES's self-test failed during srtp_init()
CPU_RISC is used for optimization only, and CPU_CISC should just work just fine,
it has been tested on android/arm with srtp test applications and libjingle.

After srtp became usable it is safe to enable SDES by default.
